### PR TITLE
Test: add method-not-allowed test for error handlers

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -151,8 +151,16 @@ class TestAccountService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 5)
-    
-     ######################################################################
+
+    ######################################################################
+    # ERROR HANDLERS - METHOD NOT ALLOWED
+    ######################################################################
+    def test_method_not_allowed(self):
+        """It should not allow an illegal method call"""
+        resp = self.client.delete(BASE_URL)
+        self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        
+    ######################################################################
     # UPDATE ACCOUNT
     ######################################################################
     def test_update_account(self):


### PR DESCRIPTION
Adds a test to ensure illegal HTTP methods are handled and return 405 (Method Not Allowed).
This exercises the Flask error handler and keeps coverage high.